### PR TITLE
Change DisplayObject generateTexture method signature to match Pixijs signature

### DIFF
--- a/pixi/display/DisplayObject.hx
+++ b/pixi/display/DisplayObject.hx
@@ -4,6 +4,7 @@ import pixi.core.Matrix;
 import pixi.core.Rectangle;
 import pixi.primitives.Graphics;
 import pixi.core.Point;
+import pixi.textures.Texture;
 
 @:native("PIXI.DisplayObject")
 extern class DisplayObject {
@@ -186,7 +187,17 @@ extern class DisplayObject {
 	*/
 	function setStageReference(stage:Stage):Void;
 
-	function generateTexture(renderer:Dynamic):Void;
+    /**
+     * Useful function that returns a texture of the displayObject object that can then be used to create sprites
+     * This can be quite useful if your displayObject is static / complicated and needs to be reused multiple times.
+     *
+     * @method generateTexture
+     * @param resolution {Number} The resolution of the texture being generated
+     * @param scaleMode {Number} Should be one of the PIXI.scaleMode consts
+     * @param renderer {CanvasRenderer|WebGLRenderer} The renderer used to generate the texture.
+     * @return {Texture} a texture of the graphics object
+     */
+	function generateTexture(resolution:Int, scaleMode:Int, renderer:Dynamic):Texture;
 
 	function updateCache():Void;
 

--- a/pixi/display/DisplayObject.hx
+++ b/pixi/display/DisplayObject.hx
@@ -199,8 +199,8 @@ extern class DisplayObject {
      * @param renderer {CanvasRenderer|WebGLRenderer} The renderer used to generate the texture.
      * @return {Texture} a texture of the graphics object
      */
-    @:overload(function(resolution:Float, scaleMode:Int, renderer:CanvasRenderer):Texture{})
-	function generateTexture(resolution:Float, scaleMode:Int, renderer:WebGLRenderer):Texture;
+    @:overload(function(resolution:Float, scaleMode:Int, ?renderer:CanvasRenderer):Texture{})
+	function generateTexture(resolution:Float, scaleMode:Int, ?renderer:WebGLRenderer):Texture;
 
 	function updateCache():Void;
 

--- a/pixi/display/DisplayObject.hx
+++ b/pixi/display/DisplayObject.hx
@@ -197,7 +197,7 @@ extern class DisplayObject {
      * @param renderer {CanvasRenderer|WebGLRenderer} The renderer used to generate the texture.
      * @return {Texture} a texture of the graphics object
      */
-	function generateTexture(resolution:Int, scaleMode:Int, renderer:Dynamic):Texture;
+	function generateTexture(resolution:Float, scaleMode:Int, renderer:Dynamic):Texture;
 
 	function updateCache():Void;
 

--- a/pixi/display/DisplayObject.hx
+++ b/pixi/display/DisplayObject.hx
@@ -5,6 +5,8 @@ import pixi.core.Rectangle;
 import pixi.primitives.Graphics;
 import pixi.core.Point;
 import pixi.textures.Texture;
+import pixi.renderers.canvas.CanvasRenderer;
+import pixi.renderers.webgl.WebGLRenderer;
 
 @:native("PIXI.DisplayObject")
 extern class DisplayObject {
@@ -197,7 +199,8 @@ extern class DisplayObject {
      * @param renderer {CanvasRenderer|WebGLRenderer} The renderer used to generate the texture.
      * @return {Texture} a texture of the graphics object
      */
-	function generateTexture(resolution:Float, scaleMode:Int, renderer:Dynamic):Texture;
+    @:overload(function(resolution:Float, scaleMode:Int, renderer:CanvasRenderer):Texture{})
+	function generateTexture(resolution:Float, scaleMode:Int, renderer:WebGLRenderer):Texture;
 
 	function updateCache():Void;
 


### PR DESCRIPTION
generateTexture method now matches:
http://www.goodboydigital.com/pixijs/docs/classes/DisplayObject.html#method_generateTexture

`pixi.primitives.Graphics` class has overloaded the generateTexture method to use only two parameters. So at the moment you have to pass `null` in as the last parameter.
Any thoughts on this?
