### PR TITLE
DisplayObject.getBounds

### DIFF
--- a/pixi/display/DisplayObject.hx
+++ b/pixi/display/DisplayObject.hx
@@ -172,7 +172,7 @@ extern class DisplayObject {
 	 * @method updateTransform
 	 * @private
 	*/
-	function getBounds(matrix:Dynamic):pixi.core.Rectangle;
+	function getBounds(?matrix:Dynamic):pixi.core.Rectangle;
 
 	/**
 	 * Sets the object's stage reference, the stage this object is connected to


### PR DESCRIPTION
the matrix parameter seems optional in Pixi.
I change the externs to reflect the original behavior.
