### PR TITLE
CloudKidStudios PixiParticles wrappers

### DIFF
--- a/pixi/plugins/particles/cloudkid/AnimatedParticle.hx
+++ b/pixi/plugins/particles/cloudkid/AnimatedParticle.hx
@@ -1,0 +1,43 @@
+package cloudkid;
+
+@:native("cloudkid:AnimatedParticle")
+extern class AnimatedParticle {
+
+	/**
+	*	An individual particle image with an animation. While this class may be functional, it
+	*	has not gotten thorough testing or examples yet, and is not considered to be release ready.
+	*	@class AnimatedParticle
+	*	@constructor
+	*	@param {Emitter} emitter The emitter that controls this AnimatedParticle.
+	*/
+	function new(e : Emitter ) : Void;
+
+	/**
+	*	Initializes the particle for use, based on the properties that have to
+	*	have been set already on the particle.
+	*	@method init
+	*/
+	function init() : Void;
+
+	/**
+	*	Sets the textures for the particle.
+	*	@method applyArt
+	*	@param {Array<pixi.textures.Texture>} art An array of pixi.textures.Texture objects for this animated particle.
+	*/
+	function applyArt(art: Array<pixi.textures.Texture) : Void;
+
+	/**
+	*	Updates the particle.
+	*	@method update
+	*	@param {Float} delta Time elapsed since the previous frame, in __seconds__.	
+	*/
+	function update( delta: Float ): Void;
+
+
+	/**
+	*	Destroys the particle, removing references and preventing future use.
+	*	@method destroy
+	*/
+	function destroy() : Void;
+
+}

--- a/pixi/plugins/particles/cloudkid/AnimatedParticle.hx
+++ b/pixi/plugins/particles/cloudkid/AnimatedParticle.hx
@@ -1,6 +1,6 @@
 package pixi.plugins.particles.cloudkid;
 
-@:native("cloudkid:AnimatedParticle")
+@:native("cloudkid.AnimatedParticle")
 extern class AnimatedParticle {
 
 	/**

--- a/pixi/plugins/particles/cloudkid/AnimatedParticle.hx
+++ b/pixi/plugins/particles/cloudkid/AnimatedParticle.hx
@@ -1,4 +1,4 @@
-package cloudkid;
+package pixi.plugins.particles.cloudkid;
 
 @:native("cloudkid:AnimatedParticle")
 extern class AnimatedParticle {
@@ -10,7 +10,7 @@ extern class AnimatedParticle {
 	*	@constructor
 	*	@param {Emitter} emitter The emitter that controls this AnimatedParticle.
 	*/
-	function new(e : Emitter ) : Void;
+	function new(e : pixi.plugins.particles.cloudkid.Emitter ) : Void;
 
 	/**
 	*	Initializes the particle for use, based on the properties that have to

--- a/pixi/plugins/particles/cloudkid/Emitter.hx
+++ b/pixi/plugins/particles/cloudkid/Emitter.hx
@@ -1,6 +1,6 @@
 package pixi.plugins.particles.cloudkid;
 
-@:native("pixi.plugins.particles.cloudkid.Emitter")
+@:native("cloudkid.Emitter")
 extern class Emitter {
 		 
 	/**

--- a/pixi/plugins/particles/cloudkid/Emitter.hx
+++ b/pixi/plugins/particles/cloudkid/Emitter.hx
@@ -1,0 +1,334 @@
+package cloudkid;
+
+@:native("cloudkid.Emitter")
+extern class Emitter {
+		 
+	/**
+	*	If either ownerPos or spawnPos has changed since the previous update.
+	*	@property {Bool} _posChanged
+	*/
+	 var _posChanged : Bool;
+
+	/**
+	*	Acceleration to apply to particles. Using this disables
+	*	any interpolation of particle speed. If the particles do
+	*	not have a rotation speed, then they will be rotated to
+	*	match the direction of travel.
+	*	@property {pixi.geom.Point} acceleration
+	*	@default null
+	*/
+	 var acceleration : pixi.geom.Point;
+
+
+	/**
+	*	If particles should be added at the back of the display list instead of the front.
+	*	@property {Bool} addAtBack
+	*/
+	 var	addAtBack : Bool;
+
+	/**
+	*	Angle at which to start spawning particles in a burst.
+	*	@property {Float} angleStart
+	*	@default 0
+	*/
+	 var	angleStart : Float;
+
+	/**
+	*	An easing function for nonlinear interpolation of values. Accepts a single
+	*	parameter of time as a value from 0-1, inclusive. Expected outputs are values
+	*	from 0-1, inclusive.
+	*	@property {Void->Void} customEase
+	*/
+	 var	customEase : Void -> Void;
+	 var	emit : Bool;
+
+
+	/**
+	*	The amount of time in seconds to emit for before setting emit to false.
+	*	A value of -1 is an unlimited amount of time.
+	*	@property {Float} emitterLifetime
+	*	@default -1
+	*/
+	 var	emitterLife : Float;
+
+	/**
+	*	The ending alpha of all particles.
+	*	@property {Float} endAlpha
+	*	@default 1
+	*/
+	 var	endAlpha : Float;
+	/**
+	*	The ending color of all particles, as red, green, and blue uints from 0-255.
+	*	@property {Array<Int>} endColor
+	*/
+	 var	endColor : Array<Int>;
+
+	/**
+	*	The ending scale of all particles.
+	*	@property {Float} endScale
+	*	@default 1
+	*/
+	 var	endScale : Float;
+
+
+	/**
+	*	The ending speed of all particles.
+	*	@property {Float} endSpeed
+	*	@default 0
+	*/
+	 var	endSpeed : Float;
+
+
+	/**
+	 *	Extra data for use in custom particles. The emitter doesn't look inside, but
+	 *	passes it on to the particle to use in init().
+	 *	@property {Dynamic} extraData
+	 */
+	 var	extraData : Dynamic;
+
+
+	/**
+	*	Time between particle spawns in seconds.
+	*	@property {Float} frequency
+	*/
+	 var	frequency : Float;
+
+	/**
+	*	The maximum lifetime for a particle, in seconds.
+	*	@property {Float} maxLifetime
+	*/
+	 var	maxLifetime : Float;
+
+	/**
+	*	Maximum number of particles to keep alive at a time. If this limit
+	*	is reached, no more particles will spawn until some have died.
+	*	@property {Int} maxParticles
+	*	@default 1000
+	*/
+	 var	maxParticles : Int;
+
+
+	/**
+	*	The maximum start rotation for a particle, in degrees. This value
+	*	is ignored if the spawn type is "burst" or "arc".
+	*	@property {Float} maxStartRotation
+	*/
+	 var	maxRotationSpeed : Float;
+
+
+	/**
+	*	The maximum rotation speed for a particle, in degrees per second.
+	*	This only visually spins the particle, it does not change direction of movement.
+	*	@property {Float} maxRotationSpeed
+	*/
+	 var	maxStartRotation : Float;
+
+	/**
+	*	A minimum multiplier for the scale of a particle at both start and
+	*	end. A value between minimumScaleMultiplier and 1 is randomly generated
+	*	and multiplied with startScale and endScale to provide the actual
+	*	startScale and endScale for each particle.
+	*	@property {Float} minimumScaleMultiplier
+	*	@default 1
+	*/
+	 var	minimumScaleMultiplier : Float;
+
+	/**
+	*	The minimum lifetime for a particle, in seconds.
+	*	@property {Float} minLifetime
+	*/
+	var	minLifetime : Float;
+
+	/**
+	*	The minimum rotation speed for a particle, in degrees per second.
+	*	This only visually spins the particle, it does not change direction of movement.
+	*	@property {Float} minRotationSpeed
+	*/
+	 var	minRotationSpeed : Float;
+
+	 
+	/**
+	*	The world position of the emitter's owner, to add spawnPos to when
+	*	spawning particles. To change this, use updateSpawnOrigin().
+	*	@property {pixi.geom.Point} ownerPos
+	*	@default {x:0, y:0}
+	*	@readOnly
+	*/
+	 var	ownerPos : pixi.geom.Point;
+
+	/**
+	*	The display object to add particles to.
+	*	@property {pixi.display.DisplayObjectContainer} parent
+	*/
+	 var	parent : pixi.display.DisplayObjectContainer;
+
+	/**
+	*	The blend mode for all particles, as named by PIXI.blendModes.
+	*	@property {Int} particleBlendMode
+	*/
+	 var	particleBlendMode : Int;
+
+	/**
+	*	An array of PIXI Texture objects.
+	*	@property {Array<pixi.textures.Texture>} particleImages
+	*/	 
+	 var	particleImage : Array<pixi.textures.Texture>;
+
+	/**
+	*	Spacing between particles in a burst. 0 gives a random angle for each particle.
+	*	@property {Float} particleSpacing
+	*	@default 0
+	*/
+	 var	particleSpacing : Float;
+
+	/**
+	*	Float of particles to spawn each wave in a burst.
+	*	@property {int} particlesPerWave
+	*	@default 1
+	*/
+	 var	particlePerWave : Int;
+
+	/**
+	*	Rotation of the emitter or emitter's owner in degrees. This is added to
+	*	the calculated spawn angle.
+	*	To change this, use rotate().
+	*	@property {Float} rotation
+	*	@default 0
+	*	@readOnly
+	*/
+	 var	rotation : Float;
+
+	/**
+	*	A circle relative to spawnPos to spawn particles inside if the spawn type is "circle".
+	*	@property {pixi.geom.Circle} spawnCircle
+	*/
+	 var	spawnCircle : pixi.geom.Circle;
+
+	/**
+	*	Position at which to spawn particles, relative to the emitter's owner's origin.
+	*	For example, the flames of a rocket travelling right might have a spawnPos
+	*	of {x:-50, y:0}.
+	*	to spawn at the rear of the rocket.
+	*	To change this, use updateSpawnPos().
+	*	@property {pixi.geom.Point} spawnPos
+	*	@readOnly
+	*/
+	 var	spawnPos : pixi.geom.Point;
+
+	/**
+	*	A rectangle relative to spawnPos to spawn particles inside if the spawn type is "rect".
+	*	@property {pixi.geom.Rectangle} spawnRect
+	*/
+	 var	spawnRect : pixi.geom.Rectangle;
+
+	/**
+	*	How the particles will be spawned. Valid types are "point", "rectangle",
+	*	"circle", "burst".
+	*	@property {String} spawnType
+	*	@readOnly
+	*/
+	 var	spawnType : String;
+
+	/**
+	*	The starting alpha of all particles.
+	*	@property {Float} startAlpha
+	*	@default 1
+	*/
+	 var	startAlpha : Float;
+	 var	startColor : Array<Int>;
+
+
+	/**
+	*	The starting scale of all particles.
+	*	@property {Float} startScale
+	*	@default 1
+	*/
+	 var	startScale : Float;
+
+	/**
+	*	The starting speed of all particles.
+	*	@property {Float} startSpeed
+	*	@default 0
+	*/
+	 var	startSpeed : Float;
+
+	/**
+	*	A particle emitter.
+	*	@class Emitter
+	*	@constructor
+	*	@param {pixi.display.DisplayObjectContainer} particleParent The display object to add the
+	*														particles to.
+	*	@param {Array<pixi.textures.Texture>} [particleImages] A texture or array of textures to use
+	*												for the particles.
+	*	@param {Dynamic} [config] A configuration object containing settings for the emitter.
+	*/
+	 function new( parent : pixi.display.DisplayObjectContainer, ?particleImages : Array<pixi.textures.Texture>, ?config : Dynamic ):Void;
+
+	/**
+	*	Kills all active particles immediately.
+	*	@method cleanup
+	*/	
+	 function cleanup() : Void;
+
+	/**
+	*	Destroys the emitter and all of its particles.
+	*	@method destroy
+	*/	
+	 function destroy() : Void;
+
+	/**
+	*	Sets up the emitter based on the config settings.
+	*	@method init
+	*	@param {Array<pixi.textures.Texture>} particleImages A texture or array of textures to use for the particles.
+	*	@param {Dynamic} config A configuration object containing settings for the emitter.
+	*/	
+	 function init( particleImages : Array<pixi.textures.Texture>, config : Dynamic ) : Void;
+
+	/**
+	*	Recycles an individual particle.
+	*	@method recycle
+	*	@param {Particle} particle The particle to recycle.
+	*/
+	 function recycle( particle : cloudkid.Particle ) : Void;
+
+	/**
+	*	Prevents emitter position interpolation in the next update.
+	*	This should be used if you made a major position change of your emitter's owner
+	*	that was not normal movement.
+	*	@method resetPositionTracking
+	*/
+	 function resetPositionTracking() : Void;
+
+
+	/**
+	*	Sets the rotation of the emitter to a new value.
+	*	@method rotate
+	*	@param {Float} newRot The new rotation, in degrees.
+	*/
+	 function rotate( newRot : Float ) : Void;
+
+	/**
+	*	Updates all particles spawned by this emitter and emits new ones.
+	*	@method update
+	*	@param {Float} delta Time elapsed since the previous frame, in __seconds__.
+	*/	 
+	 function update( delta : Float ) : Void;
+
+	/**
+	*	Changes the position of the emitter's owner. You should call this if you are adding
+	*	particles to the world display object that your emitter's owner is moving around in.
+	*	@method updateOwnerPos
+	*	@param {Float} x The new x value of the emitter's owner.
+	*	@param {Float} y The new y value of the emitter's owner.
+	*/	 
+	 function updateOwnerPos( x: Float, y : Float ) : Void;
+
+	/**
+	*	Changes the spawn position of the emitter.
+	*	@method updateSpawnPos
+	*	@param {Float} x The new x value of the spawn position for the emitter.
+	*	@param {Float} y The new y value of the spawn position for the emitter.
+	*/
+	 function updateSpawnPos( x: Float, y : Float ) : Void;
+	
+}

--- a/pixi/plugins/particles/cloudkid/Emitter.hx
+++ b/pixi/plugins/particles/cloudkid/Emitter.hx
@@ -1,6 +1,6 @@
-package cloudkid;
+package pixi.plugins.particles.cloudkid;
 
-@:native("cloudkid.Emitter")
+@:native("pixi.plugins.particles.cloudkid.Emitter")
 extern class Emitter {
 		 
 	/**
@@ -289,7 +289,7 @@ extern class Emitter {
 	*	@method recycle
 	*	@param {Particle} particle The particle to recycle.
 	*/
-	 function recycle( particle : cloudkid.Particle ) : Void;
+	 function recycle( particle : pixi.plugins.particles.cloudkid.Particle ) : Void;
 
 	/**
 	*	Prevents emitter position interpolation in the next update.

--- a/pixi/plugins/particles/cloudkid/Particle.hx
+++ b/pixi/plugins/particles/cloudkid/Particle.hx
@@ -1,6 +1,6 @@
 package pixi.plugins.particles.cloudkid;
 
-@:native("pixi.plugins.particles.cloudkid:Particle")
+@:native("cloudkid.Particle")
 extern class Particle {
 
 	/**

--- a/pixi/plugins/particles/cloudkid/Particle.hx
+++ b/pixi/plugins/particles/cloudkid/Particle.hx
@@ -1,6 +1,6 @@
-package cloudkid;
+package pixi.plugins.particles.cloudkid;
 
-@:native("cloudkid:Particle")
+@:native("pixi.plugins.particles.cloudkid:Particle")
 extern class Particle {
 
 	/**
@@ -96,7 +96,7 @@ extern class Particle {
 	*	@constructor
 	*	@param {Emitter} emitter The emitter that controls this particle.
 	*/
-	function new(emitter : cloudkid.Emitter):Void;
+	function new(emitter : pixi.plugins.particles.cloudkid.Emitter):Void;
 
 	/**
 	*	Sets the texture for the particle. This can be overridden to allow

--- a/pixi/plugins/particles/cloudkid/Particle.hx
+++ b/pixi/plugins/particles/cloudkid/Particle.hx
@@ -1,0 +1,138 @@
+package cloudkid;
+
+@:native("cloudkid:Particle")
+extern class Particle {
+
+	/**
+	*	Acceleration to apply to the particle.
+	*	@property {pixi.geom.Point} acceleration
+	*/
+	 var acceleration : pixi.geom.Point;
+
+	/**
+	*	The current age of the particle, in seconds.
+	*	@property {Float} age
+	*/
+	 var age : Float;
+
+	/**
+	*	A simple easing function to be applied to all properties that
+	*	are being interpolated.
+	*	@property {Void->Void} ease
+	*/	 
+	 var ease : Void -> Void;
+
+	/**
+	*	The emitter that controls this particle.
+	*	@property {Emitter} emitter
+	*/	 
+	 var emitter : Emitter;
+
+	/**
+	*	The alpha of the particle at the end of its life.
+	*	@property {Float} endAlpha
+	*/
+	 var endAlpha : Float;
+	 var endColor : Array<Int>;
+
+	/**
+	*	The scale of the particle at the start of its life.
+	*	@property {Float} endScale
+	*/
+	 var endScale : Float;
+
+	/**
+	*	The speed of the particle at the end of its life.
+	*	@property {Number} endSpeed
+	*/
+	 var endSpeed : Float;
+
+	/**
+	*	Extra data that the emitter passes along for custom particles.
+	*	@property {Dynamic} extraData
+	*/
+	 var extraData : Dynamic;
+
+	/**
+	*	The maximum lifetime of this particle, in seconds.
+	*	@property {Float} maxLife
+	*/	 
+	 var maxLife : Float;
+
+
+	/**
+	*	The alpha of the particle at the start of its life.
+	*	@property {Float} startAlpha
+	*/	 
+	 var startAlpha : Float;
+
+	/**
+	*	The tint of the particle at the start of its life.
+	*	@property {Array<Int>} startColor
+	*/
+	 var startColor : Array<Int>;
+
+	/**
+	*	The scale of the particle at the start of its life.
+	*	@property {Float} startScale
+	*/
+	 var startScale : Float;
+
+	/**
+	*	The speed of the particle at the start of its life.
+	*	@property {Float} startSpeed
+	*/
+	 var startSpeed : Float;
+
+	/**
+	*	The velocity of the particle. Speed may change, but the angle also
+	*	contained in velocity is constant.
+	*	@property {pixi.geom.Point} velocity
+	*/	 
+	 var velocity : pixi.geom.Point;
+
+	/**
+	*	@class Particle
+	*	@constructor
+	*	@param {Emitter} emitter The emitter that controls this particle.
+	*/
+	function new(emitter : cloudkid.Emitter):Void;
+
+	/**
+	*	Sets the texture for the particle. This can be overridden to allow
+	*	for an animated particle.
+	*	@method applyArt
+	*	@param {pixi.textures.Texture} art The texture to set.
+	*/	
+	function applyArt(art : pixi.textures.Texture):Void;
+
+
+	/**
+	*	Destroys the particle, removing references and preventing future use.
+	*	@method destroy
+	*/
+	function destroy():Void;
+
+	/**
+	*	Initializes the particle for use, based on the properties that have to
+	*	have been set already on the particle.
+	*	@method init
+	*/
+	function init():Void;
+
+	/**
+	*	Kills the particle, removing it from the display list
+	*	and telling the emitter to recycle it.
+	*	@method kill
+	*/
+	function kill():Void;
+
+	/**
+	*	Updates the particle.
+	*	@method update
+	*	@param {Float} delta Time elapsed since the previous frame, in __seconds__.
+	*	@return {Float} The standard interpolation multiplier (0-1) used for all relevant particle
+	*                    properties. A value of -1 means the particle died of old age instead.
+	*/	
+	function update(delta : Float):Float;
+}

--- a/pixi/plugins/particles/cloudkid/ParticleUtils.hx
+++ b/pixi/plugins/particles/cloudkid/ParticleUtils.hx
@@ -1,4 +1,4 @@
-package cloudkid;
+package pixi.plugins.particles.cloudkid;
 
 @:native("cloudkid.ParticleUtils")
 extern class ParticleUtils {

--- a/pixi/plugins/particles/cloudkid/ParticleUtils.hx
+++ b/pixi/plugins/particles/cloudkid/ParticleUtils.hx
@@ -1,0 +1,84 @@
+package cloudkid;
+
+@:native("cloudkid.ParticleUtils")
+extern class ParticleUtils {
+
+	/**
+	*	Combines separate color components (0-255) into a single uint color.
+	*	@method combineRGBComponents
+	*	@param {Int} r The red value of the color
+	*	@param {Int} g The green value of the color
+	*	@param {Int} b The blue value of the color
+	*	@return {Int} The color in the form of 0xRRGGBB
+	*	@static
+	*/
+	public static function combineRGBComponents(r:Int,g:Int,b:Int) : Int;
+
+	/**
+	*	Generates a custom ease function, based on the GreenSock custom ease, as demonstrated
+	*	by the related tool at http://www.greensock.com/customease/.
+	*	@method generateEase
+	*	@param {Array<Dynamic>} segments An array of segments, as created by
+	*	http://www.greensock.com/customease/.
+	*	@return {Float->Float} A function that calculates the percentage of change at
+	*						a given point in time (0-1 inclusive).
+	*	@static
+	*/	
+	public static function generateEase( Array<Dynamic>) : Float -> Float; 
+
+	/**
+	*	Gets a blend mode, ensuring that it is valid.
+	*	@method getBlendMode
+	*	@param {String} name The name of the blend mode to get.
+	*	@return {Int} The blend mode as specified in the PIXI.blendModes enumeration.
+	*	@static
+	*/	
+	public static function getBlendMode( name : String) : Int;
+
+   /**
+	*	Converts a hex string from "#AARRGGBB", "#RRGGBB", "0xAARRGGBB", "0xRRGGBB",
+	*	"AARRGGBB", or "RRGGBB" to an array of ints of 0-255 or Numbers from 0-1, as
+	*	[r, g, b, (a)].
+	*	@method hexToRGB
+	*	@param {String} color The input color string.
+	*	@param {Array<Int>} output An array to put the output in. If omitted, a new array is created.
+	*	@return {Array<Int>} The array of numeric color values.
+	*	@static
+	*/	
+	public static function hexToRGB( color : String, output : Array<Int>) : Array<Int>;
+
+	/**
+	 * Returns the length (or magnitude) of this point.
+	 * @method length
+	 * @static
+	 * @param {pixi.geom.Point} point The point to measure length
+	 * @return {Float} The length of this point.
+	 */	
+	public static function length( point : pixi.core.Point ) : Float;
+
+	/**
+	 * Reduces the point to a length of 1.
+	 * @method normalize
+	 * @static
+	 * @param {pixi.geom.Point} point The point to normalize
+	 */
+	public static function normalize( point : pixi.core.Point );
+
+	/**
+	*	Rotates a point by a given angle.
+	*	@method rotatePoint
+	*	@param {Float} angle The angle to rotate by in degrees
+	*	@param {pixi.geom.Point} p The point to rotate around 0,0.
+	*	@static
+	*/	
+	public static function rotatePoint( angle : Float, p : pixi.geom.Point );
+
+	/**
+	 * Multiplies the x and y values of this point by a value.
+	 * @method scaleBy
+	 * @static
+	 * @param {pixi.geom.Point} point The point to scaleBy
+	 * @param value {Float} The value to scale by.
+	 */	
+	public static function scaleBy( point : pixi.geom.Point, value: Float);
+}

--- a/pixi/plugins/particles/cloudkid/PathParticle.hx
+++ b/pixi/plugins/particles/cloudkid/PathParticle.hx
@@ -1,4 +1,4 @@
-package cloudkid;
+package pixi.plugins.particles.cloudkid;
 
 @:native("cloudkid:PathParticle")
 extern class PathParticle {

--- a/pixi/plugins/particles/cloudkid/PathParticle.hx
+++ b/pixi/plugins/particles/cloudkid/PathParticle.hx
@@ -1,0 +1,69 @@
+package cloudkid;
+
+@:native("cloudkid:PathParticle")
+extern class PathParticle {
+
+	/**
+	*	The function representing the path the particle should take.
+	*	@property {Float->Float} path
+	*/
+	var path: Float->Float;
+
+	/**
+	*	The initial rotation in degrees of the particle, because the direction of the path
+	*	is based on that.
+	*	@property {Float} initialRotation
+	*/
+	var initialRotation : Float;
+
+	/**
+	*	The initial position of the particle, as all path movement is added to that.
+	*	@property {pixi.geom.Point} initialPosition
+	*/
+	var initialPosition : pixi.geom.Point;
+
+	/**
+	*	Total single directional movement, due to speed.
+	*	@property {Float} movement
+	*/
+	var movement : Float;
+
+	/**
+	*	An particle that follows a path defined by an algebraic expression, e.g. "sin(x)" or
+	*	"5x + 3".
+	*	To use this class, the particle config must have a "path" string in the
+	*	"extraData" parameter. This string should have "x" in it to represent movement (from the
+	*	speed settings of the particle). It may have numbers, parentheses, the four basic
+	*	operations, and the following Math functions or properties (without the preceding "Math."):
+	*	"pow", "sqrt", "abs", "floor", "round", "ceil", "E", "PI", "sin", "cos", "tan", "asin",
+	*	"acos", "atan", "atan2", "log".
+	*	The overall movement of the particle and the expression value become x and y positions for
+	*	the particle, respectively. The final position is rotated by the spawn rotation/angle of
+	*	the particle.
+	*
+	*	Some example paths:
+	*
+	*		"sin(x/10) * 20" // A sine wave path.
+	*		"cos(x/100) * 30" // Particles curve counterclockwise (for medium speed/low lifetime particles)
+	*		"pow(x/10, 2) / 2" // Particles curve clockwise (remember, +y is down).
+	*
+	*	@class PathParticle
+	*	@constructor
+	*	@param {Emitter} emitter The emitter that controls this PathParticle.
+	*/
+	function new( Emitter ) : Void;
+
+	/**
+	*	Initializes the particle for use, based on the properties that have to
+	*	have been set already on the particle.
+	*	@method init
+	*/
+	function init() : Void;
+
+	/**
+	*	Destroys the particle, removing references and preventing future use.
+	*	@method destroy
+	*/
+	function destroy() : Void;
+	
+}

--- a/pixi/plugins/particles/cloudkid/PathParticle.hx
+++ b/pixi/plugins/particles/cloudkid/PathParticle.hx
@@ -1,6 +1,6 @@
 package pixi.plugins.particles.cloudkid;
 
-@:native("cloudkid:PathParticle")
+@:native("cloudkid.PathParticle")
 extern class PathParticle {
 
 	/**


### PR DESCRIPTION
Hi,
I just finished to wrap all the classes for https://github.com/CloudKidStudio/PixiParticles.
The documentation is also up-to-date.

I have successfully used Emitter, Particle and ParticleUtils in two projects with haxe-pixi. 
However, I have not used AnimatedParticle and PathParticle yet. 

I have been following your package naming convention.
So package name is pixi.plugins.particle.

:)
