### PR TITLE
Fix landscape bar issue on iOS

### DIFF
--- a/src/pixi/plugins/app/Application.hx
+++ b/src/pixi/plugins/app/Application.hx
@@ -184,7 +184,7 @@ class Application {
 			canvas = Browser.document.createCanvasElement();
 			canvas.style.width = width + "px";
 			canvas.style.height = height + "px";
-			canvas.style.position = "absolute";
+			canvas.style.position = "fixed";
 		}
 		else canvas = canvasElement;
 


### PR DESCRIPTION
Related to #101, it shouldn't be an `absolute` position but a `fixed` one! Do you see any downside changing this?