### PR TITLE
A few improvements and fixes

### DIFF
--- a/src/pixi/core/display/Container.hx
+++ b/src/pixi/core/display/Container.hx
@@ -47,7 +47,8 @@ extern class Container extends DisplayObject {
 	 * @param child {DisplayObject} The DisplayObject to add to the container
 	 * @return {DisplayObject} The child that was added.
 	 */
-	function addChild(child:Rest<DisplayObject>):DisplayObject;
+	@:overload(function (child:Rest<DisplayObject>):DisplayObject {})
+	function addChild<T:DisplayObject>(child:T):T;
 
 	/**
 	 * Adds a child to the container at a specified index.
@@ -57,7 +58,7 @@ extern class Container extends DisplayObject {
 	 * @param index {Int} The index to place the child in
 	 * @return {DisplayObject} The child that was added.
 	 */
-	function addChildAt(child:DisplayObject, index:Int):DisplayObject;
+	function addChildAt<T:DisplayObject>(child:T, index:Int):T;
 
 	/**
 	 * Swaps the position of 2 Display Objects within this container.

--- a/src/pixi/core/display/DisplayObject.hx
+++ b/src/pixi/core/display/DisplayObject.hx
@@ -1,13 +1,13 @@
 package pixi.core.display;
 
 import pixi.core.renderers.webgl.filters.Filter;
-import pixi.interaction.InteractionManager;
 import pixi.core.math.Matrix;
 import pixi.core.math.shapes.Rectangle;
 import pixi.core.math.Point;
+import pixi.interaction.InteractiveTarget;
 
 @:native("PIXI.DisplayObject")
-extern class DisplayObject extends InteractionManager {
+extern class DisplayObject extends InteractiveTarget {
 
 	/**
 	 * The base class for all objects that are rendered on the screen.
@@ -160,13 +160,6 @@ extern class DisplayObject extends InteractionManager {
 	var filterArea:Rectangle;
 
 	/**
-	 * Interaction shape. Children will be hit first, then this shape will be checked.
-	 *
-	 * @memberof DisplayObject#
-	 */
-	var hitArea:Dynamic;
-
-	/**
 	 * The position of the displayObject on the x axis relative to the local coordinates of the parent.
 	 *
 	 * @member {Float}
@@ -263,42 +256,6 @@ extern class DisplayObject extends InteractionManager {
 	 * @memberof DisplayObject#
 	 */
 	var filters:Array<Filter>;
-
-	/**
-	 * Indicates if the displayObject is interactive or not.
-	 *
-	 * @member {Bool}
-	 * @default false
-	 * @memberof DisplayObject#
-	 */
-	var interactive:Bool;
-
-	/**
-	 * Indicates if the displayObject uses button mode or normal mode.
-	 *
-	 * @member {Bool}
-	 * @default false
-	 * @memberof DisplayObject#
-	 */
-	var buttonMode:Bool;
-
-	/**
-	 * Indicates if the children of displayObject are interactive or not.
-	 *
-	 * @member {Bool}
-	 * @default true
-	 * @memberof DisplayObject#
-	 */
-	var interactiveChildren:Bool;
-
-	/**
-	 * Default cursor.
-	 *
-	 * @member {String}
-	 * @default pointer
-	 * @memberof DisplayObject#
-	 */
-	var defaultCursor:String;
 
 	/**
      *  Flag for if the object is accessible. If true AccessibilityManager will overlay a

--- a/src/pixi/core/ticker/Ticker.hx
+++ b/src/pixi/core/ticker/Ticker.hx
@@ -4,6 +4,55 @@ import pixi.interaction.EventEmitter;
 
 @:native("PIXI.ticker.Ticker")
 extern class Ticker extends EventEmitter {
+	
+	
+	/**
+	 * The shared ticker instance used by {@link pixi.extras.AnimatedSprite}.
+	 * and by {@link pixi.interaction.InteractionManager}.
+	 * The property {@link pixi.ticker.Ticker#autoStart} is set to `true`
+	 * for this instance. Please follow the examples for usage, including
+	 * how to opt-out of auto-starting the shared ticker.
+	 *
+	 * @example
+	 * var ticker = Ticker.shared;
+	 * // Set this to prevent starting this ticker when listeners are added.
+	 * // By default this is true only for the PIXI.ticker.shared instance.
+	 * ticker.autoStart = false;
+	 * // FYI, call this to ensure the ticker is stopped. It should be stopped
+	 * // if you have not attempted to render anything yet.
+	 * ticker.stop();
+	 * // Call this when you are ready for a running shared ticker.
+	 * ticker.start();
+	 *
+	 * @example
+	 * // You may use the shared ticker to render...
+	 * var renderer = Detector.autoDetectRenderer(800, 600);
+	 * var stage = new Container();
+	 * let interactionManager = InteractionManager(renderer);
+	 * document.body.appendChild(renderer.view);
+	 * ticker.add(function (time) {
+	 *     renderer.render(stage);
+	 * });
+	 *
+	 * @example
+	 * // Or you can just update it manually.
+	 * ticker.autoStart = false;
+	 * ticker.stop();
+	 * function animate(time) {
+	 *     ticker.update(time);
+	 *     renderer.render(stage);
+	 *     requestAnimationFrame(animate);
+	 * }
+	 * animate(performance.now());
+	 *
+	 * @type {Ticker#}
+	 * @memberof Ticker
+	 */
+	static var shared(get, never):Ticker;
+	
+	@:noCompletion inline static function get_shared():Ticker {
+		return untyped PIXI.ticker.shared;
+	}
 
 	/**
 	 * A Ticker class that runs an update loop that other objects listen to.

--- a/src/pixi/interaction/InteractiveTarget.hx
+++ b/src/pixi/interaction/InteractiveTarget.hx
@@ -1,0 +1,111 @@
+package pixi.interaction;
+import pixi.core.math.shapes.Circle;
+import pixi.core.math.shapes.Ellipse;
+import pixi.core.math.shapes.Polygon;
+import pixi.core.math.shapes.Rectangle;
+import pixi.core.math.shapes.RoundedRectangle;
+import pixi.interaction.EventEmitter;
+import haxe.extern.EitherType;
+
+@:native("PIXI.interaction.interactiveTarget")
+extern class InteractiveTarget extends EventEmitter
+{
+	/**
+	 * Indicates if the displayObject is interactive or not.
+	 *
+	 * @member {Bool}
+	 * @default false
+	 * @memberof InteractiveTarget#
+	 */
+	var interactive:Bool;
+
+	/**
+	 * Indicates if the children of displayObject are interactive or not.
+	 *
+	 * @member {Bool}
+	 * @default true
+	 * @memberof InteractiveTarget#
+	 */
+	var interactiveChildren: Bool;
+
+	/**
+	 * Interaction shape. Children will be hit first, then this shape will be checked.
+	 *	 
+	 * @member {EitherType<Rectangle, EitherType<Circle, EitherType<Ellipse, EitherType<Polygon, RoundedRectangle>>>>}
+	 * @memberof InteractiveTarget#
+	 * @default null
+	 */
+	var hitArea: EitherType< Rectangle, 
+				 EitherType< Circle, 
+				 EitherType< Ellipse,
+				 EitherType< Polygon,
+							 RoundedRectangle 
+				 >>>>;
+
+	/**
+	 * Indicates if the displayObject uses button mode or normal mode.
+	 *
+	 * @member {Bool}
+	 * @default false
+	 * @memberof InteractiveTarget#
+	 */
+	var buttonMode:Bool;
+
+	/**
+	 * Default cursor.
+	 *
+	 * @member {String}
+	 * @default pointer
+	 * @memberof InteractiveTarget#
+	 */
+	var defaultCursor:String;
+
+	// some internal checks..
+	/**
+	 * Internal check to detect if the mouse cursor is hovered over the displayObject
+	 *
+	 * @member {Bool}
+	 * @private
+	 */
+	@:noCompletion var _over: Bool;
+
+	/**
+	 * Internal check to detect if the left mouse button is pressed on the displayObject
+	 *
+	 * @member {Bool}
+	 * @private
+	 */
+	@:noCompletion var _isLeftDown: Bool;
+
+	/**
+	 * Internal check to detect if the right mouse button is pressed on the displayObject
+	 *
+	 * @member {Bool}
+	 * @private
+	 */
+	@:noCompletion var _isRightDown: Bool;
+
+	/**
+	 * Internal check to detect if the pointer cursor is hovered over the displayObject
+	 *
+	 * @member {Bool}
+	 * @private
+	 */
+	@:noCompletion var _pointerOver: Bool;
+
+	/**
+	 * Internal check to detect if the pointer is down on the displayObject
+	 *
+	 * @member {Bool}
+	 * @private
+	 */
+	@:noCompletion var _pointerDown: Bool;
+
+	/**
+	 * Internal check to detect if a user has touched the displayObject
+	 *
+	 * @member {Bool}
+	 * @private
+	 */
+	@:noCompletion var _touchDown: Bool;
+}

--- a/src/pixi/interaction/InteractiveTarget.hx
+++ b/src/pixi/interaction/InteractiveTarget.hx
@@ -10,6 +10,204 @@ import haxe.extern.EitherType;
 @:native("PIXI.interaction.interactiveTarget")
 extern class InteractiveTarget extends EventEmitter
 {
+	
+	/**
+	 * Fired when a pointer device button (usually a mouse button) is pressed on the display
+	 * object.
+	 *
+	 * @event mousedown
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function mousedown(event:EventTarget):Void;
+	
+	/**
+	 * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
+	 * on the display object.
+	 *
+	 * @event rightdown
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function rightdown(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device button (usually a mouse button) is released over the display
+	 * object.
+	 *
+	 * @event mouseup
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function mouseup(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device secondary button (usually a mouse right-button) is released
+	 * over the display object.
+	 *
+	 * @event rightup
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function rightup(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device button (usually a mouse button) is pressed and released on
+	 * the display object.
+	 *
+	 * @event click
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function click(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device secondary button (usually a mouse right-button) is pressed
+	 * and released on the display object.
+	 *
+	 * @event rightclick
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function rightclick(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device button (usually a mouse button) is released outside the
+	 * display object that initially registered a
+	 * [mousedown]{@link PIXI.interaction.InteractionManager#event:mousedown}.
+	 *
+	 * @event mouseupoutside
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function mouseupoutside(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device secondary button (usually a mouse right-button) is released
+	 * outside the display object that initially registered a
+	 * [rightdown]{@link PIXI.interaction.InteractionManager#event:rightdown}.
+	 *
+	 * @event rightupoutside
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function rightupoutside(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device (usually a mouse) is moved while over the display object
+	 *
+	 * @event mousemove
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function mousemove(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device (usually a mouse) is moved onto the display object
+	 *
+	 * @event mouseover
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function mouseover(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device (usually a mouse) is moved off the display object
+	 *
+	 * @event mouseout
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function mouseout(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device button is pressed on the display object.
+	 *
+	 * @event pointerdown
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function pointerdown(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device button is released over the display object.
+	 *
+	 * @event pointerup
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function pointerup(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device button is pressed and released on the display object.
+	 *
+	 * @event pointertap
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function pointertap(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device button is released outside the display object that initially
+	 * registered a [pointerdown]{@link PIXI.interaction.InteractionManager#event:pointerdown}.
+	 *
+	 * @event pointerupoutside
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function pointerupoutside(event:EventTarget):Void;
+
+	/**
+	 * Fired when a pointer device is moved while over the display object
+	 *
+	 * @event pointermove
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function pointermove(event:EventTarget):Void;
+	
+	/**
+	 * Fired when a pointer device is moved onto the display object
+	 *
+	 * @event pointerover
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function pointerover(event:EventTarget):Void;
+	
+	/**
+	 * Fired when a pointer device is moved off the display object
+	 *
+	 * @event pointerout
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function pointerout(event:EventTarget):Void;
+	
+	/**
+	 * Fired when a touch point is placed on the display object.
+	 *
+	 * @event touchstart
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function touchstart(event:EventTarget):Void;
+	
+	/**
+	 * Fired when a touch point is removed from the display object.
+	 *
+	 * @event touchend
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function touchend(event:EventTarget):Void;
+	
+	/**
+	 * Fired when a touch point is placed and removed from the display object.
+	 *
+	 * @event tap
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function tap(event:EventTarget):Void;
+	
+	/**
+	 * Fired when a touch point is removed outside of the display object that initially
+	 * registered a [touchstart]{@link PIXI.interaction.InteractionManager#event:touchstart}.
+	 *
+	 * @event touchendoutside
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function touchendoutside(event:EventTarget):Void;
+	 
+	/**
+	 * Fired when a touch point is moved along the display object.
+	 *
+	 * @event touchmove
+	 * @memberof InteractiveTarget#
+	 */
+	dynamic function touchmove(event:EventTarget):Void;
+	
+	
 	/**
 	 * Indicates if the displayObject is interactive or not.
 	 *

--- a/src/pixi/particles/ParticleContainer.hx
+++ b/src/pixi/particles/ParticleContainer.hx
@@ -2,6 +2,48 @@ package pixi.particles;
 
 import pixi.core.display.Container;
 
+
+/**
+ * The properties of children that should be uploaded to the gpu and applied.
+ */
+typedef ParticleContainerProperties = {
+	
+	/**
+	 * When true, scale be uploaded and applied
+	 * @default false
+	 * @member {Bool}	 
+	 */
+	?scale:Bool,
+	
+	/**
+	 * When true, position be uploaded and applied
+	 * @default true
+	 * @member {Bool}
+	 */
+	?position:Bool,
+	
+	/**
+	 * When true, rotation be uploaded and applied
+	 * @default false
+	 * @member {Bool}
+	 */
+	?rotation:Bool,
+	
+	/**
+	 * When true, uvs be uploaded and applied
+	 * @default false
+	 * @member {Bool}
+	 */
+	?uvs:Bool,
+	
+	/**
+	 * When true, alpha be uploaded and applied
+	 * @default false
+	 * @member {Bool}
+	 */
+	?alpha:Bool
+}
+
 @:native("PIXI.particles.ParticleContainer")
 extern class ParticleContainer extends Container {
 
@@ -29,20 +71,15 @@ extern class ParticleContainer extends Container {
 	 * @memberof PIXI
 	 *
 	 * @param [maxSize=15000] {Int} The number of images in the SpriteBatch before it flushes.
-	 * @param [properties] {Array<Bool>} The properties of children that should be uploaded to the gpu and applied.
-	 * @param [properties.scale=false] {Bool} When true, scale be uploaded and applied.
-	 * @param [properties.position=true] {Bool} When true, position be uploaded and applied.
-	 * @param [properties.rotation=false] {Bool} When true, rotation be uploaded and applied.
-	 * @param [properties.uvs=false] {Bool} When true, uvs be uploaded and applied.
-	 * @param [properties.alpha=false] {Bool} When true, alpha be uploaded and applied.
+	 * @param [properties] {ParticleContainerProperties} The properties of children that should be uploaded to the gpu and applied.
 	 * @param [batchSize=15000] {Int} Number of particles per batch.
 	 */
-	function new(?maxSize:Int, ?properties:Array<Bool>, ?batchSize:Int);
+	function new(?maxSize:Int, ?properties:ParticleContainerProperties, ?batchSize:Int);
 
 	/**
 	 * Sets the private properties array to dynamic / static based on the passed properties object
 	 *
 	 * @param properties {object} The properties to be uploaded
 	 */
-	function setProperties(properties:Array<Bool>):Void;
+	function setProperties(properties:ParticleContainerProperties):Void;
 }

--- a/src/pixi/particles/ParticleContainer.hx
+++ b/src/pixi/particles/ParticleContainer.hx
@@ -71,9 +71,15 @@ extern class ParticleContainer extends Container {
 	 * @memberof PIXI
 	 *
 	 * @param [maxSize=15000] {Int} The number of images in the SpriteBatch before it flushes.
-	 * @param [properties] {ParticleContainerProperties} The properties of children that should be uploaded to the gpu and applied.
+	 * @param [properties] {ParticleContainerProperties} or {Array<Bool>} The properties of children that should be uploaded to the gpu and applied.	 
+	 * @param [properties.scale=false] {Bool} When true, scale be uploaded and applied.
+	 * @param [properties.position=true] {Bool} When true, position be uploaded and applied.
+	 * @param [properties.rotation=false] {Bool} When true, rotation be uploaded and applied.
+	 * @param [properties.uvs=false] {Bool} When true, uvs be uploaded and applied.
+	 * @param [properties.alpha=false] {Bool} When true, alpha be uploaded and applied.
 	 * @param [batchSize=15000] {Int} Number of particles per batch.
 	 */
+	@:overload(function (?maxSize:Int, ?properties:Array<Bool>, ?batchSize:Int {})
 	function new(?maxSize:Int, ?properties:ParticleContainerProperties, ?batchSize:Int);
 
 	/**
@@ -81,5 +87,6 @@ extern class ParticleContainer extends Container {
 	 *
 	 * @param properties {object} The properties to be uploaded
 	 */
+	@:overload(function (?properties:Array<Bool>) {})
 	function setProperties(properties:ParticleContainerProperties):Void;
 }

--- a/src/pixi/particles/ParticleContainer.hx
+++ b/src/pixi/particles/ParticleContainer.hx
@@ -79,7 +79,7 @@ extern class ParticleContainer extends Container {
 	 * @param [properties.alpha=false] {Bool} When true, alpha be uploaded and applied.
 	 * @param [batchSize=15000] {Int} Number of particles per batch.
 	 */
-	@:overload(function (?maxSize:Int, ?properties:Array<Bool>, ?batchSize:Int {})
+	@:overload(function (?maxSize:Int, ?properties:Array<Bool>, ?batchSize:Int):Void {})
 	function new(?maxSize:Int, ?properties:ParticleContainerProperties, ?batchSize:Int);
 
 	/**
@@ -87,6 +87,6 @@ extern class ParticleContainer extends Container {
 	 *
 	 * @param properties {object} The properties to be uploaded
 	 */
-	@:overload(function (?properties:Array<Bool>) {})
+	@:overload(function (?properties:Array<Bool>):Void {})
 	function setProperties(properties:ParticleContainerProperties):Void;
 }


### PR DESCRIPTION
1. DisplayObject should extend InteractiveTarget (added by me, props and methods according to pixi source) instead of InteractionManager, since InteractionManager provides more methods and properties then InteractiveTarget actually has.
2. Added a typed variation of addChild / addChildAt to return a properly typed child (version with Rest paremeters left untouched as overload). Allows more precise typing in case of 
`var sprite = addChild(new Sprite())`
3. Added Ticker.shared to control shared ticker instance which is used by PIXI to update MovieClips. Usefull if you want to provide your own update / render loop.
4. And this one bugged me for awhile :) ParticleContainer accepts properties object, not `Array<Bool>`. So i added a typedef for that and updated methods to accept it.

Everything is commented as expected.