### PR TITLE
Typed ResourceLoader.resources

### DIFF
--- a/src/pixi/loaders/ResourceLoader.hx
+++ b/src/pixi/loaders/ResourceLoader.hx
@@ -39,7 +39,7 @@ extern class ResourceLoader extends EventEmitter {
      *
      * @member {object<string, Resource>}
      */
-	var resources:Dynamic;
+	var resources:haxe.DynamicAccess<Resource>;
 
 	/**
 	 * Adds a resource (or multiple resources) to the loader queue.


### PR DESCRIPTION
Typed ResourceLoader.resources as `haxe.DynamicAccess<Resource>`

This might break when upgrading but makes working with it a lot nicer and slightly safer.