### PR TITLE
Important fix for enums, more spine externs, Filter/RenderTarget updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
 
 language: haxe
 haxe:
-  - "3.3.0-rc.1"
+  - "3.2.1"
 hxml:
   - build.hxml
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ git:
 
 language: haxe
 haxe:
-  - "3.2.1"
+  - "3.3.0-rc.1"
 hxml:
   - build.hxml
 sudo: false

--- a/src/pixi/core/Pixi.hx
+++ b/src/pixi/core/Pixi.hx
@@ -282,99 +282,99 @@ extern class Pixi {
 
 
 @:native("PIXI.RENDERER_TYPE")
-extern enum RendererType {
-	UNKNOWN;
-	WEBGL;
-	CANVAS;
+@:enum extern abstract RendererType(Int) {
+	var UNKNOWN;
+	var WEBGL;
+	var CANVAS;
 }
 
 @:native("PIXI.SCALE_MODES")
-extern enum ScaleModes {
-	DEFAULT;
-	LINEAR;
-	NEAREST;
+@:enum extern abstract ScaleModes(Int) {
+	var DEFAULT;
+	var LINEAR;
+	var NEAREST;
 }
 
 @:native("PIXI.WRAP_MODES")
-extern enum WrapModes {
-	DEFAULT;
-	CLAMP;
-	REPEAT;
-	MIRRORED_REPEAT;
+@:enum extern abstract WrapModes(Int) {
+	var DEFAULT;
+	var CLAMP;
+	var REPEAT;
+	var MIRRORED_REPEAT;
 }
 
 @:native("PIXI.GC_MODES")
-extern enum GCModes {
-	DEFAULT;
-	AUTO;
-	MANUAL;
+@:enum extern abstract GCModes(Int) {
+	var DEFAULT;
+	var AUTO;
+	var MANUAL;
 }
 
 @:native("PIXI.BLEND_MODES")
-extern enum BlendModes {
-	NORMAL;
-	ADD;
-	MULTIPLY;
-	SCREEN;
-	OVERLAY;
-	DARKEN;
-	LIGHTEN;
-	COLOR_DODGE;
-	COLOR_BURN;
-	HARD_LIGHT;
-	SOFT_LIGHT;
-	DIFFERENCE;
-	EXCLUSION;
-	HUE;
-	SATURATION;
-	COLOR;
-	LUMINOSITY;
+@:enum extern abstract BlendModes(Int) {
+	var NORMAL;
+	var ADD;
+	var MULTIPLY;
+	var SCREEN;
+	var OVERLAY;
+	var DARKEN;
+	var LIGHTEN;
+	var COLOR_DODGE;
+	var COLOR_BURN;
+	var HARD_LIGHT;
+	var SOFT_LIGHT;
+	var DIFFERENCE;
+	var EXCLUSION;
+	var HUE;
+	var SATURATION;
+	var COLOR;
+	var LUMINOSITY;
 }
 
 @:native("PIXI.DRAW_MODES")
-extern enum DrawModes {
-	POINTS;
-	LINES;
-	LINE_LOOP;
-	LINE_STRIP;
-	TRIANGLES;
-	TRIANGLE_STRIP;
-	TRIANGLE_FAN;
+@:enum extern abstract DrawModes(Int) {
+	var POINTS;
+	var LINES;
+	var LINE_LOOP;
+	var LINE_STRIP;
+	var TRIANGLES;
+	var TRIANGLE_STRIP;
+	var TRIANGLE_FAN;
 }
 
 @:native("PIXI.SHAPES")
-extern enum Shapes {
-	POLY;
-	RECT;
-	CIRC;
-	ELIP;
-	RREC;
+@:enum extern abstract Shapes(Int) {
+	var POLY;
+	var RECT;
+	var CIRC;
+	var ELIP;
+	var RREC;
 }
 
 @:native("PIXI.PRECISIONS")
-extern enum Precisions {
-	LOW;
-	MEDIUM;
-	HIGH;
+@:enum extern abstract Precisions(String) {
+	var LOW;
+	var MEDIUM;
+	var HIGH;
 }
 
 @:native("PIXI.TEXT_GRADIENT")
-extern enum TextGradients {
-	LINEAR_VERTICAL;
-	LINEAR_HORIZONTAL;
+@:enum extern abstract TextGradients(Int) {
+	var LINEAR_VERTICAL;
+	var LINEAR_HORIZONTAL;
 }
 
 @:native("PIXI.TRANSFORM_MODE")
-extern enum TransformModes {
-	STATIC;
-	DYNAMIC;
+@:enum extern abstract TransformModes(Int) {
+	var STATIC;
+	var DYNAMIC;
 }
 
 @:native("PIXI.UPDATE_PRIORITY")
-extern enum UpdatePriotities {
-	INTERACTION;
-	HIGH;
-	NORMAL;
-	LOW;
-	UTILITY;
+@:enum extern abstract UpdatePriotities(Int) {
+	var INTERACTION;
+	var HIGH;
+	var NORMAL;
+	var LOW;
+	var UTILITY;
 }

--- a/src/pixi/core/Pixi.hx
+++ b/src/pixi/core/Pixi.hx
@@ -280,37 +280,70 @@ extern class Pixi {
 	static var UPDATE_PRIORITY:UpdatePriotities;
 }
 
-
 @:native("PIXI.RENDERER_TYPE")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract RendererType(Int) {
 	var UNKNOWN;
 	var WEBGL;
 	var CANVAS;
-}
+} 
+#else
+extern enum RendererType {
+	UNKNOWN;
+	WEBGL;
+	CANVAS;
+} 
+#end
 
 @:native("PIXI.SCALE_MODES")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract ScaleModes(Int) {
 	var DEFAULT;
 	var LINEAR;
 	var NEAREST;
 }
+#else
+extern enum ScaleModes {
+	DEFAULT;
+	LINEAR;
+	NEAREST;
+}
+#end
 
 @:native("PIXI.WRAP_MODES")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract WrapModes(Int) {
 	var DEFAULT;
 	var CLAMP;
 	var REPEAT;
 	var MIRRORED_REPEAT;
 }
+#else
+extern enum WrapModes {
+	DEFAULT;
+	CLAMP;
+	REPEAT;
+	MIRRORED_REPEAT;
+}
+#end
 
 @:native("PIXI.GC_MODES")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract GCModes(Int) {
 	var DEFAULT;
 	var AUTO;
 	var MANUAL;
 }
+#else
+extern enum GCModes {
+	DEFAULT;
+	AUTO;
+	MANUAL;
+}
+#end
 
 @:native("PIXI.BLEND_MODES")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract BlendModes(Int) {
 	var NORMAL;
 	var ADD;
@@ -330,8 +363,30 @@ extern class Pixi {
 	var COLOR;
 	var LUMINOSITY;
 }
+#else
+extern enum BlendModes {
+	NORMAL;
+	ADD;
+	MULTIPLY;
+	SCREEN;
+	OVERLAY;
+	DARKEN;
+	LIGHTEN;
+	COLOR_DODGE;
+	COLOR_BURN;
+	HARD_LIGHT;
+	SOFT_LIGHT;
+	DIFFERENCE;
+	EXCLUSION;
+	HUE;
+	SATURATION;
+	COLOR;
+	LUMINOSITY;
+}
+#end
 
 @:native("PIXI.DRAW_MODES")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract DrawModes(Int) {
 	var POINTS;
 	var LINES;
@@ -341,8 +396,20 @@ extern class Pixi {
 	var TRIANGLE_STRIP;
 	var TRIANGLE_FAN;
 }
+#else 
+extern enum DrawModes {
+	POINTS;
+	LINES;
+	LINE_LOOP;
+	LINE_STRIP;
+	TRIANGLES;
+	TRIANGLE_STRIP;
+	TRIANGLE_FAN;
+}
+#end
 
 @:native("PIXI.SHAPES")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract Shapes(Int) {
 	var POLY;
 	var RECT;
@@ -350,27 +417,63 @@ extern class Pixi {
 	var ELIP;
 	var RREC;
 }
+#else 
+extern enum Shapes {
+	POLY;
+	RECT;
+	CIRC;
+	ELIP;
+	RREC;
+}
+#end
+
 
 @:native("PIXI.PRECISIONS")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract Precisions(String) {
 	var LOW;
 	var MEDIUM;
 	var HIGH;
 }
+#else 
+extern enum Precisions {
+	LOW;
+	MEDIUM;
+	HIGH;
+}
+#end
+
 
 @:native("PIXI.TEXT_GRADIENT")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract TextGradients(Int) {
 	var LINEAR_VERTICAL;
 	var LINEAR_HORIZONTAL;
 }
+#else 
+extern enum TextGradients {
+	LINEAR_VERTICAL;
+	LINEAR_HORIZONTAL;
+}
+#end
+
 
 @:native("PIXI.TRANSFORM_MODE")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract TransformModes(Int) {
 	var STATIC;
 	var DYNAMIC;
 }
+#else 
+extern enum TransformModes {
+	STATIC;
+	DYNAMIC;
+}
+#end
+
 
 @:native("PIXI.UPDATE_PRIORITY")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract UpdatePriotities(Int) {
 	var INTERACTION;
 	var HIGH;
@@ -378,3 +481,12 @@ extern class Pixi {
 	var LOW;
 	var UTILITY;
 }
+#else 
+extern enum UpdatePriotities {
+	INTERACTION;
+	HIGH;
+	NORMAL;
+	LOW;
+	UTILITY;
+}
+#end

--- a/src/pixi/core/math/shapes/Shape.hx
+++ b/src/pixi/core/math/shapes/Shape.hx
@@ -1,21 +1,12 @@
 package pixi.core.math.shapes;
-
-@:native("PIXI.SHAPES")
-extern enum ShapeType
-{
-	POLY;
-    RECT;
-    CIRC;
-    ELIP;
-    RREC;
-}
+import pixi.core.Pixi.Shapes;
 
 extern class Shape 
 {
 	/**
 	 * Defines the type of the shape to avoid instanceof (Std.is) checks
 	 */
-	var type:ShapeType;
+	var type:Shapes;
 
 	/**
 	 * Checks whether the x and y coordinates passed to this function are contained within this Shape

--- a/src/pixi/core/renderers/webgl/filters/Filter.hx
+++ b/src/pixi/core/renderers/webgl/filters/Filter.hx
@@ -76,6 +76,14 @@ extern class Filter {
 	 * @member {Bool}
 	 */
 	var enabled:Bool;
+	
+	/**
+	 * If enabled, PixiJS will fit the filter area into boundaries for better performance. Switch it off if it does not work for specific shader.
+	 * Workaround for http://jsfiddle.net/xbmhh207/1/
+	 * @default true
+	 * @member {Bool}
+	 */
+	var autoFit:Bool;
 
 	/*
 	 * Applies the filter

--- a/src/pixi/core/renderers/webgl/filters/Filter.hx
+++ b/src/pixi/core/renderers/webgl/filters/Filter.hx
@@ -1,4 +1,6 @@
 package pixi.core.renderers.webgl.filters;
+import pixi.core.display.DisplayObject;
+import pixi.core.math.shapes.Rectangle;
 import pixi.core.renderers.webgl.managers.FilterManager;
 import pixi.core.renderers.webgl.utils.RenderTarget;
 
@@ -95,5 +97,15 @@ extern class Filter {
      *        There are some useful properties in the currentState :
      *        target, filters, sourceFrame, destinationFrame, renderTarget, resolution
 	 */
-	function apply(filterManager:FilterManager, input:RenderTarget, output:RenderTarget, ?clear:Bool, ?currentState:Dynamic):Void;
+	function apply(filterManager:FilterManager, input:RenderTarget, output:RenderTarget, ?clear:Bool, ?currentState:CurrentState):Void;
+}
+
+interface CurrentState implements Dynamic
+{
+	var destinationFrame:Rectangle;
+	var filters:Array<Filter>;
+	var renderTarget:RenderTarget;
+	var resolution:Float;
+	var sourceFrame:Rectangle;
+	var target:DisplayObject;
 }

--- a/src/pixi/core/renderers/webgl/utils/RenderTarget.hx
+++ b/src/pixi/core/renderers/webgl/utils/RenderTarget.hx
@@ -81,6 +81,13 @@ extern class RenderTarget {
 	 * @member {PIXI.Rectangle}
 	 */
 	var frame:Rectangle;
+	
+	/**
+	 * Source frame
+	 *
+	 * @member {PIXI.Rectangle}
+	 */
+	var sourceFrame:Rectangle;
 
 
 	/**

--- a/src/pixi/extras/BitmapText.hx
+++ b/src/pixi/extras/BitmapText.hx
@@ -134,11 +134,19 @@ extern class BitmapText extends Container {
 	static function registerFont(xml:XMLDocument, texture:Texture):FontObj;
 }
 
-@:enum abstract BitmapTextAlign(String) {
-	var LEFT = "left";
-	var RIGHT = "right";
-	var CENTER = "center";
+#if (haxe_ver >= 3.3)
+@:enum extern abstract BitmapTextAlign(String) {
+	var LEFT;
+	var RIGHT;
+	var CENTER;
 }
+#else
+extern enum BitmapTextAlign {
+	LEFT;
+	RIGHT;
+	CENTER;
+}
+#end
 
 typedef BitmapTextStyle = {
 	@:optional var font:Dynamic;

--- a/src/pixi/loaders/Resource.hx
+++ b/src/pixi/loaders/Resource.hx
@@ -17,13 +17,20 @@ import pixi.loaders.LoaderOptions.LoaderMetadata;
  * @property {number} LOAD_TYPE.VIDEO - Uses a `Video` object to load the resource.
  */
 @:native("PIXI.loaders.Resource.LOAD_TYPE")
-extern enum LoadType {
-	XHR; IMAGE; AUDIO; VIDEO;
+@:enum extern abstract LoadType(Int) {
+	var XHR; 
+	var IMAGE;
+	var AUDIO; 
+	var VIDEO;
 }
 
 @:native("PIXI.loaders.Resource.TYPE")
-extern enum ResourceType {
-	JSON; XML; IMAGE; AUDIO; VIDEO;
+@:enum extern abstract ResourceType(Int) {
+	var JSON; 
+	var XML; 
+	var IMAGE;
+	var AUDIO; 
+	var VIDEO;
 }
 
 @:native("PIXI.loaders.Resource")

--- a/src/pixi/loaders/Resource.hx
+++ b/src/pixi/loaders/Resource.hx
@@ -17,14 +17,24 @@ import pixi.loaders.LoaderOptions.LoaderMetadata;
  * @property {number} LOAD_TYPE.VIDEO - Uses a `Video` object to load the resource.
  */
 @:native("PIXI.loaders.Resource.LOAD_TYPE")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract LoadType(Int) {
 	var XHR; 
 	var IMAGE;
 	var AUDIO; 
 	var VIDEO;
 }
+#else 
+extern enum LoadType {
+	XHR; 
+	IMAGE;
+	AUDIO; 
+	VIDEO;
+}
+#end
 
 @:native("PIXI.loaders.Resource.TYPE")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract ResourceType(Int) {
 	var JSON; 
 	var XML; 
@@ -32,6 +42,15 @@ import pixi.loaders.LoaderOptions.LoaderMetadata;
 	var AUDIO; 
 	var VIDEO;
 }
+#else 
+extern enum ResourceType {
+	JSON; 
+	XML; 
+	IMAGE;
+	AUDIO; 
+	VIDEO;
+}
+#end
 
 @:native("PIXI.loaders.Resource")
 extern class Resource {

--- a/src/pixi/plugins/dragonbones/core/DragonBones.hx
+++ b/src/pixi/plugins/dragonbones/core/DragonBones.hx
@@ -6,11 +6,18 @@ extern class DragonBones {
 }
 
 @:native("dragonBones.DragonBones.BoundingBoxType")
-extern enum BoundingBoxType {
-	None; Rectangle; Ellipse; Polygon;
+@:enum extern abstract BoundingBoxType(Int) {
+	var None; 
+	var Rectangle; 
+	var Ellipse; 
+	var Polygon;
 }
 
 @:native("dragonBones.DragonBones.AnimationFadeOutMode")
-extern enum AnimationFadeOutMode {
-	None; SameLayer; SameGroup; SameLayerAndGroup; All;
+@:enum extern abstract AnimationFadeOutMode(Int) {
+	var None; 
+	var SameLayer; 
+	var SameGroup; 
+	var SameLayerAndGroup; 
+	var All;
 }

--- a/src/pixi/plugins/dragonbones/core/DragonBones.hx
+++ b/src/pixi/plugins/dragonbones/core/DragonBones.hx
@@ -6,14 +6,24 @@ extern class DragonBones {
 }
 
 @:native("dragonBones.DragonBones.BoundingBoxType")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract BoundingBoxType(Int) {
 	var None; 
 	var Rectangle; 
 	var Ellipse; 
 	var Polygon;
 }
+#else
+extern enum BoundingBoxType {
+	None; 
+	Rectangle; 
+	Ellipse; 
+	Polygon;
+}
+#end
 
 @:native("dragonBones.DragonBones.AnimationFadeOutMode")
+#if (haxe_ver >= 3.3)
 @:enum extern abstract AnimationFadeOutMode(Int) {
 	var None; 
 	var SameLayer; 
@@ -21,3 +31,12 @@ extern class DragonBones {
 	var SameLayerAndGroup; 
 	var All;
 }
+#else
+extern enum AnimationFadeOutMode {
+	None; 
+	SameLayer; 
+	SameGroup; 
+	SameLayerAndGroup; 
+	All;
+}
+#end

--- a/src/pixi/plugins/spine/core/AtlasAttachmentLoader.hx
+++ b/src/pixi/plugins/spine/core/AtlasAttachmentLoader.hx
@@ -1,0 +1,8 @@
+package pixi.plugins.spine.core;
+
+@:native("PIXI.spine.core.AtlasAttachmentLoader")
+extern class AtlasAttachmentLoader implements AttachmentLoader
+{
+
+	function new(atlas:TextureAtlas):Void;
+}

--- a/src/pixi/plugins/spine/core/AttachmentLoader.hx
+++ b/src/pixi/plugins/spine/core/AttachmentLoader.hx
@@ -1,0 +1,7 @@
+package pixi.plugins.spine.core;
+
+//TODO
+interface AttachmentLoader 
+{
+  
+}

--- a/src/pixi/plugins/spine/core/Disposable.hx
+++ b/src/pixi/plugins/spine/core/Disposable.hx
@@ -1,0 +1,7 @@
+package pixi.plugins.spine.core;
+
+
+interface Disposable 
+{
+	function dispose():Void;
+}

--- a/src/pixi/plugins/spine/core/SkeletonJson.hx
+++ b/src/pixi/plugins/spine/core/SkeletonJson.hx
@@ -1,0 +1,14 @@
+package pixi.plugins.spine.core;
+
+import haxe.extern.EitherType;
+
+@:native("PIXI.spine.core.SkeletonJson")
+extern class SkeletonJson 
+{
+
+	function new(attachementsLoader:AttachmentLoader):Void;
+	
+	var scale:Float;
+	
+	function readSkeletonData(json: EitherType<String, Dynamic>): SkeletonData;
+}

--- a/src/pixi/plugins/spine/core/TextureAtlas.hx
+++ b/src/pixi/plugins/spine/core/TextureAtlas.hx
@@ -1,0 +1,39 @@
+package pixi.plugins.spine.core;
+import haxe.DynamicAccess;
+import pixi.core.textures.BaseTexture;
+import pixi.core.textures.Texture;
+
+
+@:native("PIXI.spine.core.TextureAtlas")
+extern class TextureAtlas implements Disposable {
+	var pages: Array<TextureAtlasPage>;
+	var regions:  Array<TextureAtlasRegion>;
+	function new(?atlasText: String, textureLoader: String->(BaseTexture-> Void)->Void, ?callback:TextureAtlas->Void);
+	
+	function addTexture(name: String, texture: Texture): TextureAtlasRegion;
+	function addTextureHash(textures: Dynamic<Texture>, stripExtension: Bool): Void;
+	function addSpineAtlas(?atlasText: String, textureLoader: String->(BaseTexture-> Void)->Void, ?callback:TextureAtlas->Void): Void;
+	//private load(atlasText, textureLoader, callback);
+	function findRegion(name: String): TextureAtlasRegion;
+	function dispose(): Void;
+}
+
+@:native("PIXI.spine.core.TextureAtlasPage")
+extern class TextureAtlasPage {
+	var name: String;
+	//var minFilter: TextureFilter;
+	//var magFilter: TextureFilter;
+	//var uWrap: TextureWrap;
+	//var vWrap: TextureWrap;
+	var baseTexture: BaseTexture;
+	var width: Int;
+	var height: Int;
+	function setFilters(): Void;
+}
+
+@:native("PIXI.spine.core.TextureAtlasRegion")
+extern class TextureAtlasRegion extends TextureRegion {
+	var page: TextureAtlasPage;
+	var name: String;
+	var index: Int;
+}

--- a/src/pixi/plugins/spine/core/TextureRegion.hx
+++ b/src/pixi/plugins/spine/core/TextureRegion.hx
@@ -1,0 +1,10 @@
+package pixi.plugins.spine.core;
+
+//TODO
+@:native("PIXI.spine.core.TextureRegion")
+class TextureRegion 
+{
+
+
+	
+}


### PR DESCRIPTION
Changes:
* Important: all enums changed from `extern enum` to `@:enum extern abstract` for switch statements to work
* Spine externs updated to be able to parse inlined (or staticly declared) spine data
* +Filter.autoFit
* +RenderTarget.sourceFrame to implement custom filters
* +FilterManager apply currentState typed (still allows Dynamic access)