### PR TITLE
DisplayObject list return on removeChildren

### DIFF
--- a/src/pixi/core/display/Container.hx
+++ b/src/pixi/core/display/Container.hx
@@ -113,8 +113,9 @@ extern class Container extends DisplayObject {
 	 *
 	 * @param beginIndex {Int} The beginning position. Default value is 0.
 	 * @param endIndex {Int} The ending position. Default value is size of the container.
+	 * @returns {DisplayObject[]} List of removed children
 	 */
-	function removeChildren(?beginIndex:Int, ?endIndex:Int):Void;
+	function removeChildren(?beginIndex:Int, ?endIndex:Int):Array<DisplayObject>;
 
 	/**
 	* Returns the display object in the container


### PR DESCRIPTION
Container now returns list of children that were removed.

https://github.com/pixijs/pixi.js/blob/dev/src/core/display/Container.js#L275