### PR TITLE
Fix CanvasRenderTarget extern class

### DIFF
--- a/src/pixi/core/renderers/canvas/utils/CanvasRenderTarget.hx
+++ b/src/pixi/core/renderers/canvas/utils/CanvasRenderTarget.hx
@@ -3,7 +3,7 @@ package pixi.core.renderers.canvas.utils;
 import js.html.CanvasRenderingContext2D;
 import js.html.CanvasElement;
 
-@:native("CanvasRenderTarget")
+@:native("PIXI.CanvasRenderTarget")
 extern class CanvasRenderTarget {
 
 	/**


### PR DESCRIPTION
This fix is required in order to use the class, otherwise referencing it in code will result in a `Uncaught ReferenceError: CanvasRenderTarget is not defined` runtime error.