### PR TITLE
haxe 4 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: haxe
 haxe:
   - "3.2.1"
   - "3.4.7"
+  - "4.0.0-rc.3"
   
 hxml:
   - build.hxml

--- a/build.hxml
+++ b/build.hxml
@@ -1,6 +1,5 @@
 -cmd haxelib newrepo
 -cmd haxelib install perf.js || true
--cmd haxelib install nape || true
 -cmd haxelib install msignal || true
 -cmd haxelib install actuate || true
 -cmd haxelib install chxdoc || true
@@ -47,11 +46,6 @@
 --next
 -main dragging.Main
 -js samples/output/dragging.js
-
---next
--main nape.Main
--js samples/output/nape.js
--lib nape
 
 --next
 -main rope.Main

--- a/samples/src/loader/Main.hx
+++ b/samples/src/loader/Main.hx
@@ -2,7 +2,11 @@ package loader;
 
 import js.html.URL;
 import js.html.Blob;
+#if (haxe_ver >= 4)
+import js.lib.Uint8Array;
+#else
 import js.html.Uint8Array;
+#end
 import pixi.core.utils.Utils;
 import pixi.core.textures.BaseTexture;
 import js.html.Image;

--- a/src/pixi/core/Pixi.hx
+++ b/src/pixi/core/Pixi.hx
@@ -1,7 +1,12 @@
 package pixi.core;
 
 import haxe.extern.EitherType;
+
+#if (haxe_ver >= 4)
+import js.lib.RegExp;
+#else
 import js.RegExp;
+#end
 
 @:native("PIXI")
 extern class Pixi {

--- a/src/pixi/core/renderers/webgl/extract/WebGLExtract.hx
+++ b/src/pixi/core/renderers/webgl/extract/WebGLExtract.hx
@@ -1,7 +1,11 @@
 package pixi.core.renderers.webgl.extract;
 import js.html.CanvasElement;
 import js.html.ImageElement;
+#if (haxe_ver >= 4)
+import js.lib.Uint8ClampedArray;
+#else
 import js.html.Uint8ClampedArray;
+#end
 import pixi.core.display.DisplayObject;
 import pixi.core.renderers.webgl.WebGLRenderer;
 import pixi.core.textures.RenderTexture;

--- a/src/pixi/extras/TextureTransform.hx
+++ b/src/pixi/extras/TextureTransform.hx
@@ -1,6 +1,10 @@
 package pixi.extras;
 
+#if (haxe_ver >= 4)
+import js.lib.Float32Array;
+#else
 import js.html.Float32Array;
+#end
 import pixi.core.textures.Texture;
 
 @:native("PIXI.extras.TextureTransform")

--- a/src/pixi/mesh/Mesh.hx
+++ b/src/pixi/mesh/Mesh.hx
@@ -2,10 +2,16 @@ package pixi.mesh;
 
 import pixi.core.Pixi.BlendModes;
 import pixi.core.math.Point;
+#if (haxe_ver >= 4)
+import js.lib.Uint16Array;
+import js.lib.Float32Array;
+import js.lib.Int16Array;
+#else
 import js.html.Uint16Array;
-import pixi.core.Shader;
 import js.html.Float32Array;
 import js.html.Int16Array;
+#end
+import pixi.core.Shader;
 import pixi.core.display.Container;
 import pixi.core.textures.Texture;
 


### PR DESCRIPTION
See #159 

- Haxe 4 RC 3 has been added to travis config
- Conditionals for packages that have been moved to js.lib
- Removed the nape example since nape didn't get updates for a few years and has no haxe 4 support yet. https://github.com/HaxeFlixel/nape-haxe4 might be an alternative.