### PR TITLE
Added blend modes to Mesh and re-enabled rendering for canvas renderers

### DIFF
--- a/src/pixi/core/renderers/AbstractRenderer.hx
+++ b/src/pixi/core/renderers/AbstractRenderer.hx
@@ -141,4 +141,14 @@ extern class AbstractRenderer extends EventEmitter {
 	 * @param	screenHeight The new height of the screen.
 	 */
 	function resize(screenWidth:Float, screenHeight:Float):Void;
+
+	/**
+	 * Renders the object to its WebGL or Canvas view
+	 * @param	displayObject The object to be rendered.
+	 * @param	renderTexture The render texture to render to.
+	 * @param	clear Should the canvas be cleared before the new render.
+	 * @param	transform A transform to apply to the render texture before rendering.
+	 * @param	skipUpdateTransform Should we skip the update transform pass?
+	 */
+	function render(displayObject:DisplayObject, ?renderTexture:RenderTarget, ?clear:Bool = true, ?transform:Matrix, skipUpdateTransform:Bool = false):Void;
 }

--- a/src/pixi/core/renderers/AbstractRenderer.hx
+++ b/src/pixi/core/renderers/AbstractRenderer.hx
@@ -7,7 +7,9 @@ import pixi.core.RenderOptions;
 import pixi.core.display.DisplayObject;
 import pixi.core.math.shapes.Rectangle;
 import pixi.core.textures.RenderTexture;
+import pixi.core.renderers.webgl.utils.RenderTarget;
 import pixi.interaction.EventEmitter;
+import pixi.core.math.Matrix;
 
 @:native("PIXI.AbstractRenderer")
 extern class AbstractRenderer extends EventEmitter {

--- a/src/pixi/core/renderers/webgl/Renderer.hx
+++ b/src/pixi/core/renderers/webgl/Renderer.hx
@@ -20,10 +20,8 @@ import pixi.core.renderers.systems.StencilSystem;
 import pixi.core.renderers.systems.TextureGCSystem;
 import pixi.core.renderers.systems.TextureSystem;
 import pixi.core.renderers.webgl.extract.Extract;
-import pixi.core.renderers.webgl.utils.RenderTarget;
 import pixi.core.textures.Texture;
 import pixi.core.textures.RenderTexture;
-import pixi.core.math.Matrix;
 import pixi.core.renderers.webgl.managers.MaskManager;
 import pixi.core.renderers.systems.FilterSystem;
 

--- a/src/pixi/core/renderers/webgl/Renderer.hx
+++ b/src/pixi/core/renderers/webgl/Renderer.hx
@@ -148,16 +148,6 @@ extern class Renderer extends AbstractRenderer {
 	function clear():Void;
 
 	/**
-	 * Renders the object to its WebGL view
-	 * @param	displayObject The object to be rendered.
-	 * @param	renderTexture The render texture to render to.
-	 * @param	clear Should the canvas be cleared before the new render.
-	 * @param	transform A transform to apply to the render texture before rendering.
-	 * @param	skipUpdateTransform Should we skip the update transform pass?
-	 */
-	function render(displayObject:DisplayObject, ?renderTexture:RenderTarget, ?clear:Bool = true, ?transform:Matrix, skipUpdateTransform:Bool = false):Void;
-
-	/**
 	 * Resets the WebGL state so you can render things however you fancy!
 	 * @return Returns itself.
 	 */

--- a/src/pixi/mesh/Mesh.hx
+++ b/src/pixi/mesh/Mesh.hx
@@ -153,8 +153,3 @@ extern class Mesh extends Container {
 	 */
 	function renderAdvanced(render:Renderer):Void;
 }
-
-typedef DrawModes = {
-	var TRIANGLE_MESH:Int;
-	var TRIANGLES:Int;
-}

--- a/src/pixi/mesh/Mesh.hx
+++ b/src/pixi/mesh/Mesh.hx
@@ -10,6 +10,9 @@ import pixi.core.renderers.webgl.Buffer;
 import pixi.core.renderers.webgl.Renderer;
 import pixi.core.renderers.webgl.State;
 import pixi.core.textures.Texture;
+import pixi.core.Pixi.BlendModes;
+import pixi.core.Pixi.DrawModes;
+
 
 @:native("PIXI.Mesh")
 extern class Mesh extends Container {
@@ -34,11 +37,18 @@ extern class Mesh extends Container {
 	static var BATCHABLE_SIZE:Float;
 
 	/**
-	 * The way the Mesh should be drawn, can be any of the Mesh.DRAW_MODES consts
+	* The blend mode to be applied to the Mesh. Apply a value of PIXI.BLEND_MODES.NORMAL to reset the blend mode.
+	*
+	* @member {BlendModes}
+	*/
+	var blendMode:BlendModes;
+
+	/**
+	 * The way the Mesh should be drawn, can be any of the PIXI.DRAW_MODES consts
 	 *
-	 * @member {Int}
+	 * @member {DrawModes}
 	 */
-	var drawMode:Int;
+	var drawMode:DrawModes;
 
 	/**
 		Includes vertex positions, face indices, normals, colors, UVs, and custom attributes within buffers, reducing the cost of passing all this data to the GPU. Can be shared between multiple Mesh objects.

--- a/src/pixi/mesh/Mesh.hx
+++ b/src/pixi/mesh/Mesh.hx
@@ -40,7 +40,7 @@ extern class Mesh extends Container {
 	* The blend mode to be applied to the Mesh. Apply a value of PIXI.BLEND_MODES.NORMAL to reset the blend mode.
 	*
 	* @member {BlendModes}
-	*/
+	 */
 	var blendMode:BlendModes;
 
 	/**

--- a/src/pixi/mesh/Mesh.hx
+++ b/src/pixi/mesh/Mesh.hx
@@ -13,7 +13,6 @@ import pixi.core.textures.Texture;
 import pixi.core.Pixi.BlendModes;
 import pixi.core.Pixi.DrawModes;
 
-
 @:native("PIXI.Mesh")
 extern class Mesh extends Container {
 	/**


### PR DESCRIPTION
Hello, 

This is just a small update to match the newest pixi interfaces. The changes are as follows:

- Added the `blendMode` field to the Mesh extern. This allows users to set blend modes on components like `NineSlicePlane`.
- Updated the `blendMode` and `drawMode` field in the Mesh extern to use the PIXI enums instead of Ints. 
- Moved the render function definition into the `AbstractRenderer `enum. This should allow users of the webgl only version of pixi to be unaffected, as `Renderer `extends `AbstractRenderer`.
- The main benefit is also allowing for the use of the `CanvasRenderer `once again (for those using the pixi-legacy package). Previously, the `CanvasRenderer `was not usable. 
- A useful side effect of moving the function into the `AbstractRenderer `extern is that it allows for dynamic polymorphism. It allows for user code to have a single code path that deals with the parent type of `AbstractRenderer`. 