### PR TITLE
Remove unnecessary deprecated __js__ call

### DIFF
--- a/src/pixi/core/ticker/Ticker.hx
+++ b/src/pixi/core/ticker/Ticker.hx
@@ -49,7 +49,7 @@ extern class Ticker extends EventEmitter {
 	static var shared(get, never):Ticker;
 
 	@:noCompletion inline static function get_shared():Ticker {
-		return cast untyped __js__("PIXI.Ticker.shared");
+		return cast untyped PIXI.Ticker.shared;
 	}
 
 	/**


### PR DESCRIPTION
This will prevent some warnings from haxe compiler.